### PR TITLE
Set up project structure with MkDocs and example notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.pytest_cache/
+.ipynb_checkpoints/
+site/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# trading_blog
+# Trading Blog
+
+This project hosts a simple trading blog built with [MkDocs](https://www.mkdocs.org). 
+It aims to share trading ideas and Python examples through notebooks and posts.
+
+## Project Goals
+
+- Document and experiment with trading strategies.
+- Provide example notebooks and reusable Python modules in `src/`.
+- Publish the blog with GitHub Pages.
+
+## Getting Started
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install mkdocs jupyter pandas yfinance matplotlib
+   ```
+
+2. Serve the site locally:
+
+   ```bash
+   mkdocs serve
+   ```
+
+   Then open `http://127.0.0.1:8000/` in your browser.
+
+3. Explore the notebooks in the `notebooks/` directory with Jupyter.
+
+## Deployment
+
+The site is configured for GitHub Pages using MkDocs. Build and deploy with:
+
+```bash
+mkdocs gh-deploy
+```
+
+This command creates or updates the `gh-pages` branch containing the static site.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# Trading Blog
+
+Welcome to the trading blog built with MkDocs.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: Trading Blog
+site_url: https://example.com
+nav:
+  - Home: index.md
+docs_dir: docs
+

--- a/notebooks/simple_trading_idea.ipynb
+++ b/notebooks/simple_trading_idea.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple Moving Average Crossover\n",
+    "This example downloads daily prices for SPY and computes two moving averages. The crossover of the fast and slow averages is used as a trading signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import yfinance as yf\n",
+    "\n",
+    "data = yf.download('SPY', start='2020-01-01', end='2020-12-31')\n",
+    "data['fast_ma'] = data['Close'].rolling(window=20).mean()\n",
+    "data['slow_ma'] = data['Close'].rolling(window=50).mean()\n",
+    "signals = (data['fast_ma'] > data['slow_ma']).astype(int)\n",
+    "signals.value_counts()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- update README with goals and setup instructions
- add `.gitignore`
- add MkDocs site configuration and simple docs page
- create example moving-average notebook
- scaffold `src/`, `notebooks/`, and `docs/` directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f7e8a74988325b99ee4dcf97fe39d